### PR TITLE
Skip training license holders from results

### DIFF
--- a/Eindopdracht_Triathlon_V3.cpp
+++ b/Eindopdracht_Triathlon_V3.cpp
@@ -240,7 +240,7 @@ int leeftijd_op_datum(const string& geboortedatum, const string& datum)
     return leeftijd;
 }
 
-// categorieën volgens jouw eisen
+// categorieÃ«n volgens jouw eisen
 string categorie_van_leeftijd(int leeftijd)
 {
     if (leeftijd < 13)
@@ -352,6 +352,14 @@ void toon_uitslag_van_wedstrijd(const vector<Wedstrijd>& wedstrijden)
 
     const Wedstrijd& wedstrijd = wedstrijden[wedstrijd_index];
     auto uitslag = wedstrijd.deelnemer_lijst_gesorteerd(); // gesorteerd op totale tijd
+
+    // deelnemers met een Trainingslicentie worden niet opgenomen in de uitslag
+    uitslag.erase(remove_if(uitslag.begin(), uitslag.end(),
+        [](const Deelnemer& d)
+        {
+            return d.get_atleet().get_licentie().get_type() == "Trainingslicentie";
+        }), uitslag.end());
+
     if (uitslag.empty())
     {
         cout << "Geen deelnemers voor deze wedstrijd.\n";


### PR DESCRIPTION
## Summary
- Exclude athletes with a training license from competition results and category rankings.

## Testing
- `g++ -std=c++17 *.cpp -o triathlon`


------
https://chatgpt.com/codex/tasks/task_e_68c30b3825b0832095d3c076cb3aa9c7