### PR TITLE
Voorkom dubbele licentienummers bij koppeling

### DIFF
--- a/Eindopdracht_Triathlon_V3.cpp
+++ b/Eindopdracht_Triathlon_V3.cpp
@@ -668,8 +668,19 @@ int main() {
 
                     int licentienummer;
                     string geldig_tot;
-                    cout << "Licentienummer: ";
-                    cin >> licentienummer;
+                    bool bestaat;
+                    do {
+                        bestaat = false;
+                        cout << "Licentienummer: ";
+                        cin >> licentienummer;
+                        for (size_t i = 0; i < atleten.size(); ++i) {
+                            if (i != (size_t)atleet_index && atleten[i].get_licentie().get_nummer() == licentienummer) {
+                                bestaat = true;
+                                cout << "Licentienummer bestaat al. Probeer opnieuw.\n";
+                                break;
+                            }
+                        }
+                    } while (bestaat);
                     cout << "Geldig tot (bv. 31-12-2024): ";
                     cin >> geldig_tot;
 


### PR DESCRIPTION
## Samenvatting
- Controle toegevoegd die bij het invoeren van een licentienummer nagaat of dit nummer al aan een andere atleet is gekoppeld.
- Gebruiker wordt herhaaldelijk om een nieuw nummer gevraagd totdat een uniek licentienummer is opgegeven.

## Testinstructies
- `g++ -std=c++17 *.cpp -o triathlon`


------
https://chatgpt.com/codex/tasks/task_e_68c312ad0cd88320b64beb9fadf25056