### PR TITLE
Check doping status before race enrollment

### DIFF
--- a/Eindopdracht_Triathlon_V3.cpp
+++ b/Eindopdracht_Triathlon_V3.cpp
@@ -592,16 +592,23 @@ int main() {
                         {
                             string licentie_datum = atleten[atleet_index].get_licentie().get_geldig_tot();
                             string wedstrijd_datum = wedstrijden[wedstrijd_index].get_datum();
-                            if (licentie_datum != wedstrijd_datum)
-                            {
-                                cout << "Daglicentie is alleen geldig op de dag van de wedstrijd.\n";
-                                cout << "Inschrijving geweigerd.\n";
-                                continue; // ga terug naar het hoofdmenu (while-loop)
-                            }
+                        if (licentie_datum != wedstrijd_datum)
+                        {
+                            cout << "Daglicentie is alleen geldig op de dag van de wedstrijd.\n";
+                            cout << "Inschrijving geweigerd.\n";
+                            continue; // ga terug naar het hoofdmenu (while-loop)
                         }
+                    }
 
-                        int tijd_zwem, tijd_fiets, tijd_loop;
-                        cout << "Tijden in seconden.\n";
+                    // Controleer op positieve dopingcontroles
+                    if (!atleten[atleet_index].get_licentie().is_dopingvrij())
+                    {
+                        cout << "Atleet heeft een positieve dopingcontrole. Inschrijving geweigerd.\n";
+                        continue;
+                    }
+
+                    int tijd_zwem, tijd_fiets, tijd_loop;
+                    cout << "Tijden in seconden.\n";
                         cout << "Zwem: ";
                         cin >> tijd_zwem;
                         cout << "Fiets: ";

--- a/Licentie.cpp
+++ b/Licentie.cpp
@@ -32,6 +32,18 @@ const vector<DopingControle>& Licentie::get_doping_controles() const
     return doping_controles;
 }
 
+bool Licentie::is_dopingvrij() const
+{
+    for (const auto& controle : doping_controles)
+    {
+        if (controle.doping_geconstateerd)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
 void Licentie::set_nummer(int nummer)
 {
     licentie_nummer = nummer;

--- a/Licentie.h
+++ b/Licentie.h
@@ -31,6 +31,9 @@ public:
     string get_vereniging() const;
     const vector<DopingControle>& get_doping_controles() const;
 
+    // Dopingstatus
+    bool is_dopingvrij() const;
+
     //Setters
     void set_nummer(int nummer);
     void set_geldig_tot(const string& geldig_tot);


### PR DESCRIPTION
## Summary
- Add `is_dopingvrij` method to `Licentie` to determine if any positive doping controls exist
- Prevent athletes with positive doping controls from enrolling in a race

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic -o triathlon Eindopdracht_Triathlon_V3.cpp Atleet.cpp Deelnemer.cpp Licentie.cpp Wedstrijd.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68c4306da3688320802226f0a8e8cb0c