### PR TITLE
Filter dopingpositieve atleten uit uitslag

### DIFF
--- a/Eindopdracht_Triathlon_V3.cpp
+++ b/Eindopdracht_Triathlon_V3.cpp
@@ -360,6 +360,13 @@ void toon_uitslag_van_wedstrijd(const vector<Wedstrijd>& wedstrijden)
             return d.get_atleet().get_licentie().get_type() == "Trainingslicentie";
         }), uitslag.end());
 
+    // dopingpositieve atleten worden niet opgenomen in de uitslag
+    uitslag.erase(remove_if(uitslag.begin(), uitslag.end(),
+        [](const Deelnemer& d)
+        {
+            return !d.get_atleet().get_licentie().is_dopingvrij();
+        }), uitslag.end());
+
     if (uitslag.empty())
     {
         cout << "Geen deelnemers voor deze wedstrijd.\n";


### PR DESCRIPTION
## Summary
- sluit atleten met een positieve dopingcontrole uit bij het genereren van de uitslag

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic *.cpp -o triathlon`
- `./triathlon <<'EOF'
9
0
10
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68c46b4fac208320921b43d91384efeb