### PR TITLE
Add license validity check

### DIFF
--- a/Eindopdracht_Triathlon_V3.cpp
+++ b/Eindopdracht_Triathlon_V3.cpp
@@ -349,6 +349,13 @@ void toon_uitslag_van_wedstrijd(const vector<Wedstrijd>& wedstrijden)
             return d.get_atleet().get_licentie().get_type() == "Trainingslicentie";
         }), uitslag.end());
 
+    // deelnemers met verlopen licentie worden niet opgenomen in de uitslag
+    uitslag.erase(remove_if(uitslag.begin(), uitslag.end(),
+        [&](const Deelnemer& d)
+        {
+            return !d.get_atleet().get_licentie().is_geldig_op(wedstrijd.get_datum());
+        }), uitslag.end());
+
     // dopingpositieve atleten worden niet opgenomen in de uitslag
     uitslag.erase(remove_if(uitslag.begin(), uitslag.end(),
         [](const Deelnemer& d)
@@ -590,28 +597,11 @@ int main() {
                         }
 
                         // Controleer of licentie nog geldig is ten opzichte van wedstrijddatum
+                        if (!atleten[index_atleet].get_licentie().is_geldig_op(
+                            wedstrijden[wedstrijd_index].get_datum()))
                         {
-                            string licentie_geldig_tot = atleten[index_atleet].get_licentie().get_geldig_tot();
-                            string wedstrijd_datum = wedstrijden[wedstrijd_index].get_datum();
-
-                            int licentie_dag = get_dag(licentie_geldig_tot);
-                            int licentie_maand = get_maand(licentie_geldig_tot);
-                            int licentie_jaar = get_jaar(licentie_geldig_tot);
-                            int wedstrijd_dag = get_dag(wedstrijd_datum);
-                            int wedstrijd_maand = get_maand(wedstrijd_datum);
-                            int wedstrijd_jaar = get_jaar(wedstrijd_datum);
-
-                            bool licentie_verlopen =
-                                (licentie_jaar < wedstrijd_jaar) ||
-                                (licentie_jaar == wedstrijd_jaar &&
-                                    (licentie_maand < wedstrijd_maand ||
-                                        (licentie_maand == wedstrijd_maand && licentie_dag < wedstrijd_dag)));
-
-                            if (licentie_verlopen)
-                            {
-                                cout << "Licentie verlopen. Inschrijving geweigerd.\n";
-                                continue;
-                            }
+                            cout << "Licentie verlopen. Inschrijving geweigerd.\n";
+                            continue;
                         }
 
                     // Controleer op positieve dopingcontroles

--- a/Licentie.cpp
+++ b/Licentie.cpp
@@ -44,6 +44,21 @@ bool Licentie::is_dopingvrij() const
     return true;
 }
 
+// Controleer of licentie geldig is op gegeven datum ("dd-mm-jjjj")
+bool Licentie::is_geldig_op(const string& datum) const
+{
+    if (geldig_tot.size() != 10 || datum.size() != 10)
+        return false; // ongeldige datumformaten
+
+    auto to_int = [](const string& d) {
+        return stoi(d.substr(6, 4) + d.substr(3, 2) + d.substr(0, 2));
+    };
+
+    int datum_int = to_int(datum);
+    int geldig_int = to_int(geldig_tot);
+    return datum_int <= geldig_int;
+}
+
 void Licentie::set_nummer(int nummer)
 {
     licentie_nummer = nummer;

--- a/Licentie.h
+++ b/Licentie.h
@@ -34,6 +34,9 @@ public:
     // Dopingstatus
     bool is_dopingvrij() const;
 
+    // Geldigheid
+    bool is_geldig_op(const string& datum) const;
+
     //Setters
     void set_nummer(int nummer);
     void set_geldig_tot(const string& geldig_tot);


### PR DESCRIPTION
## Summary
- add `is_geldig_op` helper to `Licentie` to check date against expiration
- validate licenses during registration and exclude expired licenses from results

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic -o triathlon *.cpp`


------
https://chatgpt.com/codex/tasks/task_e_68c5562cd3f083209daec6454be47850