### PR TITLE
Use explicit NK flag name

### DIFF
--- a/Eindopdracht_Triathlon_V3.cpp
+++ b/Eindopdracht_Triathlon_V3.cpp
@@ -50,7 +50,7 @@ void save_data()
     {
         bestand << wedstrijd.get_naam() << '\n'
             << wedstrijd.get_datum() << '\n'
-            << wedstrijd.get_is_nk() << '\n'
+            << wedstrijd.get_is_nederlands_kampioenschap() << '\n'
             << wedstrijd.get_met_wissels() << '\n';
 
         const auto& deelnemers = wedstrijd.get_deelnemers();
@@ -122,11 +122,11 @@ void load_data()
         string naam, datum;
         getline(in, naam);
         getline(in, datum);
-        int is_nk_int, met_wissels_int;
-        in >> is_nk_int >> met_wissels_int;
+        int is_nederlands_kampioenschap_int, met_wissels_int;
+        in >> is_nederlands_kampioenschap_int >> met_wissels_int;
         in.ignore(numeric_limits<streamsize>::max(), '\n');
 
-        Wedstrijd wedstrijd(naam, datum, is_nk_int != 0, met_wissels_int != 0);
+        Wedstrijd wedstrijd(naam, datum, is_nederlands_kampioenschap_int != 0, met_wissels_int != 0);
 
         size_t aantal_deelnemers;
         in >> aantal_deelnemers;
@@ -542,7 +542,7 @@ int main() {
         if (keuze == 1)
         {
             string naam, datum;
-            string is_nk_keuze, wissels_keuze;
+            string is_nederlands_kampioenschap_keuze, wissels_keuze;
 
             naam = lees_tekst("Naam wedstrijd: ");
             do {
@@ -551,15 +551,15 @@ int main() {
                     cout << "Ongeldige datum. Probeer opnieuw.\n";
             } while (!valide_datum(datum));
 
-            is_nk_keuze = lees_tekst("Is NK? (ja/nee): ");
+            is_nederlands_kampioenschap_keuze = lees_tekst("Is Nederlands Kampioenschap? (ja/nee): ");
 
             wissels_keuze = lees_tekst("Wisseltijden registreren? (ja/nee): ");
 
-            bool is_nk = (is_nk_keuze == "ja");
+            bool is_nederlands_kampioenschap = (is_nederlands_kampioenschap_keuze == "ja");
             bool heeft_wissels = (wissels_keuze == "ja");
 
             // nieuw object maken en toevoegen aan de vector
-            Wedstrijd nieuwe_wedstrijd(naam, datum, is_nk, heeft_wissels);
+            Wedstrijd nieuwe_wedstrijd(naam, datum, is_nederlands_kampioenschap, heeft_wissels);
             wedstrijden.push_back(nieuwe_wedstrijd);
 
             cout << "Wedstrijd aangemaakt met index ["
@@ -614,7 +614,7 @@ int main() {
                     string licentie_type = atleten[index_atleet].get_licentie().get_type();
 
                         // NK-licentiecontrole
-                        if (wedstrijden[wedstrijd_index].get_is_nk())
+                        if (wedstrijden[wedstrijd_index].get_is_nederlands_kampioenschap())
                         {
                             if (licentie_type != "Wedstrijdlicentie") {
                                 cout << "Deze wedstrijd is een NK, atleet heeft geen Wedstrijdlicentie.\n";

--- a/Wedstrijd.cpp
+++ b/Wedstrijd.cpp
@@ -3,8 +3,11 @@
 
 using namespace std;
 
-Wedstrijd::Wedstrijd(string wedstrijd_naam, string wedstrijd_datum, bool is_nk, bool heeft_wissels)
-    : naam(wedstrijd_naam), datum(wedstrijd_datum), is_nk(is_nk), met_wissels(heeft_wissels) {}
+Wedstrijd::Wedstrijd(string wedstrijd_naam, string wedstrijd_datum, bool is_nederlands_kampioenschap, bool heeft_wissels)
+    : naam(wedstrijd_naam),
+      datum(wedstrijd_datum),
+      is_nederlands_kampioenschap(is_nederlands_kampioenschap),
+      met_wissels(heeft_wissels) {}
 
 void Wedstrijd::voeg_deelnemer_toe(const Deelnemer& nieuwe_deelnemer)
 {
@@ -42,9 +45,9 @@ bool Wedstrijd::get_met_wissels() const
     return met_wissels;
 }
 
-bool Wedstrijd::get_is_nk() const
+bool Wedstrijd::get_is_nederlands_kampioenschap() const
 {
-    return is_nk;
+    return is_nederlands_kampioenschap;
 }
 
 vector<Deelnemer> Wedstrijd::deelnemer_lijst_gesorteerd() const

--- a/Wedstrijd.h
+++ b/Wedstrijd.h
@@ -11,7 +11,7 @@ private:
     string naam;
     string datum; // voor nu simpel als string "dd-mm-jjjj"
 
-    bool is_nk
+    bool is_nederlands_kampioenschap
     {
         false
     };
@@ -25,7 +25,7 @@ private:
 
 public:
     Wedstrijd() = default;
-    Wedstrijd(string wedstrijd_naam, string wedstrijd_datum, bool is_nk, bool heeft_wissels);
+    Wedstrijd(string wedstrijd_naam, string wedstrijd_datum, bool is_nederlands_kampioenschap, bool heeft_wissels);
 
     // basisacties
     void voeg_deelnemer_toe(const Deelnemer& nieuwe_deelnemer);
@@ -40,5 +40,5 @@ public:
     string get_naam() const;
     string get_datum() const;
     bool get_met_wissels() const;
-    bool get_is_nk() const;
+    bool get_is_nederlands_kampioenschap() const;
 };


### PR DESCRIPTION
## Summary
- Rename `is_nk` member to `is_nederlands_kampioenschap` for clarity
- Update constructor, getter, file I/O, and prompts to use explicit flag name

## Testing
- `g++ -std=c++17 *.cpp -o triathlon_program`


------
https://chatgpt.com/codex/tasks/task_e_68c5697ee1088320aa1ca5596d08c40f