### PR TITLE
Organize function order for clarity

### DIFF
--- a/Atleet.cpp
+++ b/Atleet.cpp
@@ -1,9 +1,10 @@
 #include "Atleet.h"
 
+// constructors
+Atleet::Atleet() : geslacht(' '), licentie(Licentie(0, "", "", "")) {}
+
 Atleet::Atleet(string voornaam, string achternaam, string geboortedatum, char geslacht)
     : voornaam(voornaam), achternaam(achternaam), geboortedatum(geboortedatum), geslacht(geslacht), licentie(Licentie(0, "", "", "")) {}
-
-Atleet::Atleet() : geslacht(' '), licentie(Licentie(0, "", "", "")) {}
 
 //Setters
 void Atleet::set_voornaam(string nieuwe_voornaam)

--- a/Wedstrijd.cpp
+++ b/Wedstrijd.cpp
@@ -29,6 +29,17 @@ const vector<Deelnemer>& Wedstrijd::get_deelnemers() const
     return deelnemers;
 }
 
+vector<Deelnemer> Wedstrijd::deelnemer_lijst_gesorteerd() const
+{
+    vector<Deelnemer> gesorteerde_deelnemers = deelnemers; // kopie om het origineel niet te wijzigen
+    sort(gesorteerde_deelnemers.begin(), gesorteerde_deelnemers.end(),
+        [](const Deelnemer& eerste, const Deelnemer& tweede)
+        {
+            return eerste.totale_tijd() < tweede.totale_tijd();
+        });
+    return gesorteerde_deelnemers;
+}
+
 //getters
 string Wedstrijd::get_naam() const
 {
@@ -48,15 +59,4 @@ bool Wedstrijd::get_met_wissels() const
 bool Wedstrijd::get_is_nederlands_kampioenschap() const
 {
     return is_nederlands_kampioenschap;
-}
-
-vector<Deelnemer> Wedstrijd::deelnemer_lijst_gesorteerd() const
-{
-    vector<Deelnemer> gesorteerde_deelnemers = deelnemers; // kopie om het origineel niet te wijzigen
-    sort(gesorteerde_deelnemers.begin(), gesorteerde_deelnemers.end(),
-        [](const Deelnemer& eerste, const Deelnemer& tweede)
-        {
-            return eerste.totale_tijd() < tweede.totale_tijd();
-        });
-    return gesorteerde_deelnemers;
 }

--- a/Wedstrijd.h
+++ b/Wedstrijd.h
@@ -33,7 +33,6 @@ public:
     // simpele output (kan later klassement worden)
     int aantal_deelnemers() const;
     const vector<Deelnemer>& get_deelnemers() const;
-
     vector<Deelnemer> deelnemer_lijst_gesorteerd() const;
 
     //getters


### PR DESCRIPTION
## Summary
- Place `Atleet` default constructor before the parameterized one and label constructors for clarity.
- Move `deelnemer_lijst_gesorteerd` before the getter block in `Wedstrijd` and group it with other output functions in the header.

## Testing
- `g++ -std=c++17 Atleet.cpp Deelnemer.cpp Licentie.cpp Wedstrijd.cpp Eindopdracht_Triathlon_V3.cpp -o triathlon`
- `./triathlon <<'EOF'
10
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68c571abffac83208bc536aa67da2036