### PR TITLE
Parse integers manually without extra includes

### DIFF
--- a/Eindopdracht_Triathlon_V3.cpp
+++ b/Eindopdracht_Triathlon_V3.cpp
@@ -251,24 +251,43 @@ int lees_int(const string& prompt)
 {
     while (true)
     {
-        try
-        {
-            string input;
-            cout << prompt;
-            if (!(cin >> input))
-                throw runtime_error("fout");
-            int value = stoi(input);
-            if (value >= 0)
-            {
-                return value;
-            }
-        }
-        catch (...)
+        string input;
+        cout << prompt;
+        if (!(cin >> input))
         {
             cout << "Ongeldige invoer. Voer een niet-negatief getal in.\n";
             cin.clear();
             cin.ignore(numeric_limits<streamsize>::max(), '\n');
+            continue;
         }
+
+        bool ok = !input.empty();
+        int value = 0;
+        for (char c : input)
+        {
+            if (c < '0' || c > '9')
+            {
+                ok = false;
+                break;
+            }
+
+            int digit = c - '0';
+            if (value > (numeric_limits<int>::max() - digit) / 10)
+            {
+                ok = false;
+                break;
+            }
+            value = value * 10 + digit;
+        }
+
+        if (ok)
+        {
+            return value;
+        }
+
+        cout << "Ongeldige invoer. Voer een niet-negatief getal in.\n";
+        cin.clear();
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
 }
 


### PR DESCRIPTION
## Summary
- Drop unnecessary `<charconv>` header
- Manually parse non-negative integer input in `lees_int`

## Testing
- `g++ -std=c++17 Atleet.cpp Deelnemer.cpp Eindopdracht_Triathlon_V3.cpp Wedstrijd.cpp Licentie.cpp -o triathlon && echo "compile ok"`


------
https://chatgpt.com/codex/tasks/task_e_68c68ba009a08320a31eace55675d37b