### PR TITLE
Simplify date conversion in license validity check

### DIFF
--- a/Licentie.cpp
+++ b/Licentie.cpp
@@ -51,7 +51,11 @@ bool Licentie::is_geldig_op(const string& datum) const
         return false; // ongeldige datumformaten
 
     auto datum_naar_int = [](const string& d) {
-        return stoi(d.substr(6, 4) + d.substr(3, 2) + d.substr(0, 2));
+        int jaar = (d[6]-'0') * 1000 + (d[7]-'0') * 100 +
+                   (d[8]-'0') * 10 + (d[9]-'0');
+        int maand = (d[3]-'0') * 10 + (d[4]-'0');
+        int dag = (d[0]-'0') * 10 + (d[1]-'0');
+        return jaar * 10000 + maand * 100 + dag;
     };
 
     int datum_als_int = datum_naar_int(datum);


### PR DESCRIPTION
## Summary
- extract year, month, and day parts with simple char arithmetic and combine into a single date integer

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic *.cpp -o triathlon`
- `./triathlon <<'EOF'
10
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68c68e9347788320a78854833f1c7f16