### PR TITLE
Remove runtime_error from input reader

### DIFF
--- a/Eindopdracht_Triathlon_V3.cpp
+++ b/Eindopdracht_Triathlon_V3.cpp
@@ -304,23 +304,16 @@ int kies_index(int max_index, const string& prompt)
 
 string lees_tekst(const string& prompt)
 {
+    string input;
     while (true)
     {
-        try
-        {
-            string input;
-            cout << prompt;
-            cin.clear();
-            if (!getline(cin >> ws, input))
-                throw runtime_error("fout");
+        cout << prompt;
+        cin.clear();
+        if (getline(cin >> ws, input))
             return input;
-        }
-        catch (...)
-        {
-            cout << "Ongeldige invoer. Probeer opnieuw.\n";
-            cin.clear();
-            cin.ignore(numeric_limits<streamsize>::max(), '\n');
-        }
+        cout << "Ongeldige invoer. Probeer opnieuw.\n";
+        cin.clear();
+        cin.ignore(numeric_limits<streamsize>::max(), '\n');
     }
 }
 


### PR DESCRIPTION
## Summary
- Simplify `lees_tekst` by handling `getline` errors without exceptions

## Testing
- `g++ -std=c++17 Atleet.cpp Deelnemer.cpp Licentie.cpp Wedstrijd.cpp Eindopdracht_Triathlon_V3.cpp -o triathlon`


------
https://chatgpt.com/codex/tasks/task_e_68c69486bad08320afe8a8a4571575d5