### PR TITLE
Add GoogleTest coverage for Licentie::is_geldig_op

### DIFF
--- a/Eindopdracht_Triathlon_V3_TEST/Eindopdracht_Triathlon_V3_TEST/test.cpp
+++ b/Eindopdracht_Triathlon_V3_TEST/Eindopdracht_Triathlon_V3_TEST/test.cpp
@@ -1,6 +1,46 @@
 #include "pch.h"
+#include "../Licentie.h"
 
-TEST(TestCaseName, TestName) {
-  EXPECT_EQ(1, 1);
-  EXPECT_TRUE(true);
+// Basistests voor Licentie::is_geldig_op volgens de opgegeven tabel.
+
+TEST(LicentieIsGeldigOpTest, DaglicentieOpZelfdeDagGeldig)
+{
+    Licentie licentie(1, "15-03-2025", "Daglicentie");
+    EXPECT_TRUE(licentie.is_geldig_op("15-03-2025"));
+}
+
+TEST(LicentieIsGeldigOpTest, DaglicentieVoorDagOngeldig)
+{
+    Licentie licentie(1, "15-03-2025", "Daglicentie");
+    EXPECT_FALSE(licentie.is_geldig_op("14-03-2025"));
+}
+
+TEST(LicentieIsGeldigOpTest, DaglicentieNaDagOngeldig)
+{
+    Licentie licentie(1, "15-03-2025", "Daglicentie");
+    EXPECT_FALSE(licentie.is_geldig_op("16-03-2025"));
+}
+
+TEST(LicentieIsGeldigOpTest, WedstrijdlicentieBeginDagGeldig)
+{
+    Licentie licentie(2, "31-12-2025", "Wedstrijdlicentie");
+    EXPECT_TRUE(licentie.is_geldig_op("01-01-2025"));
+}
+
+TEST(LicentieIsGeldigOpTest, WedstrijdlicentieEindDagGeldig)
+{
+    Licentie licentie(2, "31-12-2025", "Wedstrijdlicentie");
+    EXPECT_TRUE(licentie.is_geldig_op("31-12-2025"));
+}
+
+TEST(LicentieIsGeldigOpTest, WedstrijdlicentieNaEindDatumOngeldig)
+{
+    Licentie licentie(2, "31-12-2025", "Wedstrijdlicentie");
+    EXPECT_FALSE(licentie.is_geldig_op("01-01-2026"));
+}
+
+TEST(LicentieIsGeldigOpTest, OngeldigeDatum)
+{
+    Licentie licentie(3, "31-12-2025", "Wedstrijdlicentie");
+    EXPECT_FALSE(licentie.is_geldig_op("29-02-2023"));
 }


### PR DESCRIPTION
## Summary
- add GoogleTest unit tests for `Licentie::is_geldig_op` covering dag- en wedstrijdlicentie
- verify behavior for grensgevallen zoals dezelfde dag, buiten de geldigheidsperiode en ongeldige datum

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a70080648320809599fecd5226b2