### PR TITLE
Expose valide_datum implementation to tests

### DIFF
--- a/Eindopdracht_Triathlon_V3.cpp
+++ b/Eindopdracht_Triathlon_V3.cpp
@@ -14,6 +14,7 @@
 #include "Deelnemer.h"
 #include "Wedstrijd.h"
 #include "Licentie.h"
+#include "valide_datum.h"
 
 using namespace std;
 
@@ -181,43 +182,6 @@ void print_keuzemenu()
     cout << "8. Dopingcontrole toevoegen\n";
     cout << "9. Uitslagen tonen\n";
     cout << "10. Stoppen\n"; // De terminal bleef zwart, menu niet zichtbaar terwijl de code wel leek te werken
-}
-
-/**
- * @brief Controleert of een datum in het formaat dd-mm-jjjj geldig is.
- * @param datum Te controleren datumstring.
- * @return True als de datum geldig is, anders false.
- */
-bool valide_datum(const string& datum)
-{
-    if (datum.size() != 10 || datum[2] != '-' || datum[5] != '-')
-        return false;
-    for (size_t datum_index = 0; datum_index < datum.size(); ++datum_index)
-    {
-        if (datum_index == 2 || datum_index == 5)
-            continue;
-        char c = datum[datum_index];
-        if (c < '0' || c > '9')
-            return false;
-    }
-    int dag = (datum[0] - '0') * 10 + (datum[1] - '0');
-    int maand = (datum[3] - '0') * 10 + (datum[4] - '0');
-    int jaar = (datum[6] - '0') * 1000 + (datum[7] - '0') * 100 + (datum[8] - '0') * 10 + (datum[9] - '0');
-    if (jaar < 1900 || jaar > 2100)
-        return false;
-    if (maand < 1 || maand > 12)
-        return false;
-    int dagen_per_maand[] = { 31,28,31,30,31,30,31,31,30,31,30,31 };
-    int dagen = dagen_per_maand[maand - 1];
-    if (maand == 2)
-    {
-        bool leap = (jaar % 4 == 0 && (jaar % 100 != 0 || jaar % 400 == 0));
-        if (leap)
-            dagen = 29;
-    }
-    if (dag < 1 || dag > dagen)
-        return false;
-    return true;
 }
 
 // datum helpers voor "dd-mm-jjjj"

--- a/Eindopdracht_Triathlon_V3_TEST/Eindopdracht_Triathlon_V3_TEST/test.cpp
+++ b/Eindopdracht_Triathlon_V3_TEST/Eindopdracht_Triathlon_V3_TEST/test.cpp
@@ -4,6 +4,7 @@
 #include "Deelnemer.h"
 #include "Wedstrijd.h"
 #include <vector>
+#include "valide_datum.h"
 
 using namespace std;
 
@@ -78,6 +79,102 @@ TEST(licentie_is_geldig_op_test, ongeldige_datum)
 {
     Licentie licentie(3, "31-12-2025", "Wedstrijdlicentie");
     EXPECT_FALSE(licentie.is_geldig_op("29-02-2023"));
+}
+
+// Coverage tests voor valide_datum (statement en decision coverage).
+
+// Statement coverage scenario's (T1 t/m T7 uit de tabel).
+
+TEST(valide_datum_statement_coverage, T1_basispad_geldige_datum)
+{
+    EXPECT_TRUE(valide_datum("15-07-2023"));
+}
+
+TEST(valide_datum_statement_coverage, T2_ongeldige_lengte)
+{
+    EXPECT_FALSE(valide_datum("1-7-2023"));
+}
+
+TEST(valide_datum_statement_coverage, T3_teken_geen_cijfer)
+{
+    EXPECT_FALSE(valide_datum("a5-07-2023"));
+}
+
+TEST(valide_datum_statement_coverage, T4_jaar_buiten_bereik)
+{
+    EXPECT_FALSE(valide_datum("10-10-2201"));
+}
+
+TEST(valide_datum_statement_coverage, T5_maand_buiten_bereik)
+{
+    EXPECT_FALSE(valide_datum("10-13-2020"));
+}
+
+TEST(valide_datum_statement_coverage, T6_februari_schrikkeljaar)
+{
+    EXPECT_TRUE(valide_datum("29-02-2020"));
+}
+
+TEST(valide_datum_statement_coverage, T7_februari_geen_schrikkeljaar)
+{
+    EXPECT_FALSE(valide_datum("29-02-2021"));
+}
+
+// Decision (branch) coverage scenario's (T1 t/m T11 uit de tabel).
+
+TEST(valide_datum_branch_coverage, T1_geldige_pad)
+{
+    EXPECT_TRUE(valide_datum("15-07-2023"));
+}
+
+TEST(valide_datum_branch_coverage, T2_teken_kleiner_dan_nul)
+{
+    EXPECT_FALSE(valide_datum("/5-07-2023"));
+}
+
+TEST(valide_datum_branch_coverage, T3_teken_groter_dan_negen)
+{
+    EXPECT_FALSE(valide_datum("a5-07-2023"));
+}
+
+TEST(valide_datum_branch_coverage, T4_schrikkeljaar_true)
+{
+    EXPECT_TRUE(valide_datum("29-02-2020"));
+}
+
+TEST(valide_datum_branch_coverage, T5_schrikkeljaar_false)
+{
+    EXPECT_FALSE(valide_datum("29-02-2021"));
+}
+
+TEST(valide_datum_branch_coverage, T6_maand_ongeldig_hoog)
+{
+    EXPECT_FALSE(valide_datum("22-19-2020"));
+}
+
+TEST(valide_datum_branch_coverage, T7_maand_ongeldig_laag)
+{
+    EXPECT_FALSE(valide_datum("10-00-2019"));
+}
+
+TEST(valide_datum_branch_coverage, T8_dag_boven_maximum)
+{
+    EXPECT_FALSE(valide_datum("32-12-2020"));
+}
+
+TEST(valide_datum_branch_coverage, T9_dag_boven_maximum_in_april)
+{
+    EXPECT_FALSE(valide_datum("31-04-2020"));
+}
+
+TEST(valide_datum_branch_coverage, T10_jaar_te_klein)
+{
+    EXPECT_FALSE(valide_datum("12-12-1899"));
+}
+
+TEST(valide_datum_branch_coverage, T11_jaar_te_groot)
+{
+    EXPECT_FALSE(valide_datum("12-12-2101"));
 }
 
 // Basistests voor Licentie::is_dopingvrij volgens de opgegeven tabel.

--- a/valide_datum.cpp
+++ b/valide_datum.cpp
@@ -1,0 +1,34 @@
+#include "valide_datum.h"
+
+bool valide_datum(const std::string& datum)
+{
+    if (datum.size() != 10 || datum[2] != '-' || datum[5] != '-')
+        return false;
+    for (size_t datum_index = 0; datum_index < datum.size(); ++datum_index)
+    {
+        if (datum_index == 2 || datum_index == 5)
+            continue;
+        char c = datum[datum_index];
+        if (c < '0' || c > '9')
+            return false;
+    }
+    int dag = (datum[0] - '0') * 10 + (datum[1] - '0');
+    int maand = (datum[3] - '0') * 10 + (datum[4] - '0');
+    int jaar = (datum[6] - '0') * 1000 + (datum[7] - '0') * 100 + (datum[8] - '0') * 10 + (datum[9] - '0');
+    if (jaar < 1900 || jaar > 2100)
+        return false;
+    if (maand < 1 || maand > 12)
+        return false;
+    int dagen_per_maand[] = { 31,28,31,30,31,30,31,31,30,31,30,31 };
+    int dagen = dagen_per_maand[maand - 1];
+    if (maand == 2)
+    {
+        bool leap = (jaar % 4 == 0 && (jaar % 100 != 0 || jaar % 400 == 0));
+        if (leap)
+            dagen = 29;
+    }
+    if (dag < 1 || dag > dagen)
+        return false;
+    return true;
+}
+

--- a/valide_datum.h
+++ b/valide_datum.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <string>
+
+bool valide_datum(const std::string& datum);
+


### PR DESCRIPTION
## Summary
- add a shared header and translation unit for valide_datum so both the app and tests can use the same implementation
- include the new header in the main source and tests to replace the manual forward declaration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da979b132483209484d722f89263e1